### PR TITLE
feat: add support for AsyncWrite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ members = [
     "hdfs-examples",
     "hdfs-testing",
 ]
+
+[patch.crates-io]
+object_store = { git = "https://github.com/yjshen/arrow-rs.git", branch = "pub_multipart_upload" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ members = [
 ]
 
 [patch.crates-io]
-object_store = { git = "https://github.com/yjshen/arrow-rs.git", branch = "pub_multipart_upload" }
+object_store = { git = "https://github.com/apache/arrow-rs.git", rev = "bff6155d38e19bfe62a776731b78b435560f2c8e" }

--- a/hdfs/Cargo.toml
+++ b/hdfs/Cargo.toml
@@ -46,5 +46,5 @@ chrono = { version = "0.4" }
 fs-hdfs = { version = "^0.1.11", optional = true }
 fs-hdfs3 = { version = "^0.1.11", optional = true }
 futures = "0.3"
-object_store = "0.6"
+object_store = { version = "0.6", features = ["cloud"] }
 tokio = { version = "1.18", features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot"] }

--- a/hdfs/Cargo.toml
+++ b/hdfs/Cargo.toml
@@ -46,5 +46,5 @@ chrono = { version = "0.4" }
 fs-hdfs = { version = "^0.1.11", optional = true }
 fs-hdfs3 = { version = "^0.1.11", optional = true }
 futures = "0.3"
-object_store = "0.5.4"
+object_store = "0.6"
 tokio = { version = "1.18", features = ["macros", "rt", "rt-multi-thread", "sync", "parking_lot"] }

--- a/hdfs/src/object_store/hdfs.rs
+++ b/hdfs/src/object_store/hdfs.rs
@@ -29,10 +29,7 @@ use chrono::{DateTime, NaiveDateTime, Utc};
 use futures::{stream::BoxStream, StreamExt, TryStreamExt};
 use hdfs::hdfs::{get_hdfs_by_full_path, FileStatus, HdfsErr, HdfsFile, HdfsFs};
 use hdfs::walkdir::HdfsWalkDir;
-use object_store::{
-    path::{self, Path},
-    Error, GetResult, ListResult, MultipartId, ObjectMeta, ObjectStore, Result,
-};
+use object_store::{path::{self, Path}, Error, GetResult, ListResult, MultipartId, ObjectMeta, ObjectStore, Result, GetOptions};
 use tokio::io::AsyncWrite;
 
 /// scheme for HDFS File System
@@ -174,6 +171,10 @@ impl ObjectStore for HadoopFileSystem {
         Ok(GetResult::Stream(
             futures::stream::once(async move { Ok(blob) }).boxed(),
         ))
+    }
+
+    async fn get_opts(&self, _location: &Path, _options: GetOptions) -> Result<GetResult> {
+        todo!()
     }
 
     async fn get_range(&self, location: &Path, range: Range<usize>) -> Result<Bytes> {
@@ -410,6 +411,7 @@ pub fn convert_metadata(file: FileStatus, prefix: &str) -> ObjectMeta {
             Utc,
         ),
         size: file.len(),
+        e_tag: None,
     }
 }
 


### PR DESCRIPTION
Discovered the remarkable pull request https://github.com/apache/arrow-datafusion/pull/6987, which enables writing data through the Object Store API with AsyncWriter.

We can support writing directly to HDFS once we add support for the `put_multipart` and `abort_multipart` APIs.